### PR TITLE
adding CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @temporalio/devrel @Sushisource
+* @temporalio/DevRel @Sushisource

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @temporalio/developer-relations-entra-sync @Sushisource
+* @temporalio/devrel @Sushisource

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @temporalio/devrel @Sushisource

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @temporalio/devrel @Sushisource
+* @temporalio/developer-relations-entra-sync @Sushisource


### PR DESCRIPTION
## What was changed
I added a `CODEOWNERS` file, as per a recent discussion with Spencer.

## Why?
<!-- Tell your future self why have you made these changes -->
To comply with IT team requirements and adhere to GitHub best practices. 

Although there's no imminent work expected on this repo following Ziggy's safe return to earth, I want to make sure we monitor it for issues and PRs. To that end, I've created a CODEOWNERS file that lists the DevRel team as co-owners, along with Spencer (who did the original work).